### PR TITLE
fix: replace ssh2 with system ssh binary for tunnel

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,10 +2,10 @@ import { app, BrowserWindow, ipcMain, dialog, globalShortcut, Menu } from 'elect
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import fs from 'node:fs/promises'
-import fsSync from 'node:fs'
 import net from 'node:net'
 import os from 'node:os'
-import { Client as SSHClient } from 'ssh2'
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
 import Store from 'electron-store'
 import contextMenu from 'electron-context-menu'
 
@@ -123,6 +123,8 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL ? path.join(process.env.APP_ROOT, 
 let win: BrowserWindow | null
 
 // ─── SSH Tunnel ────────────────────────────────────────────────────────────
+// Uses the system `ssh` binary (same as terminal) instead of a JS SSH
+// implementation — avoids native module issues and routing quirks.
 
 export interface SSHConfig {
   host: string
@@ -132,8 +134,7 @@ export interface SSHConfig {
   remotePort: number
 }
 
-let sshClient: InstanceType<typeof SSHClient> | null = null
-let tunnelServer: net.Server | null = null
+let sshProcess: ChildProcess | null = null
 
 function getAvailablePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -148,78 +149,55 @@ function getAvailablePort(): Promise<number> {
 
 function destroySSHTunnel(): Promise<void> {
   return new Promise((resolve) => {
-    const cleanup = () => {
-      if (sshClient) { sshClient.end(); sshClient = null }
-      resolve()
-    }
-    if (tunnelServer) {
-      tunnelServer.close(() => { tunnelServer = null; cleanup() })
-    } else {
-      cleanup()
-    }
+    if (!sshProcess) { resolve(); return }
+    const proc = sshProcess
+    sshProcess = null
+    proc.kill()
+    proc.once('exit', () => resolve())
+    setTimeout(resolve, 1000) // force resolve after 1s if process hangs
   })
 }
 
 function createSSHTunnel(config: SSHConfig): Promise<number> {
-  return destroySSHTunnel().then(() => new Promise((resolve, reject) => {
-    const client = new SSHClient()
-    sshClient = client
-
+  return destroySSHTunnel().then(() => getAvailablePort()).then((localPort) => new Promise((resolve, reject) => {
     const keyPath = (config.privateKeyPath || '~/.ssh/id_rsa').replace(/^~/, os.homedir())
-    let privateKey: Buffer
-    try {
-      privateKey = fsSync.readFileSync(keyPath)
-    } catch {
-      return reject(new Error(`SSH key not found: ${keyPath}`))
-    }
 
-    client.on('ready', async () => {
-      let localPort: number
-      try { localPort = await getAvailablePort() } catch (e) { return reject(e) }
+    const args = [
+      '-N',                                     // no remote command
+      '-o', 'StrictHostKeyChecking=accept-new', // TOFU — accept new, reject changed
+      '-o', 'ExitOnForwardFailure=yes',         // fail fast if port forward fails
+      '-o', 'ServerAliveInterval=30',           // keep-alive
+      '-o', 'BatchMode=yes',                    // no interactive prompts
+      '-L', `${localPort}:127.0.0.1:${config.remotePort}`,
+      '-p', String(config.port || 22),
+      '-i', keyPath,
+      `${config.username}@${config.host}`,
+    ]
 
-      const server = net.createServer((socket) => {
-        client.forwardOut('127.0.0.1', localPort, '127.0.0.1', config.remotePort, (err, stream) => {
-          if (err) { socket.destroy(); return }
-          socket.pipe(stream)
-          stream.pipe(socket)
-          socket.on('close', () => stream.end())
-          stream.on('close', () => socket.destroy())
-        })
+    const proc = spawn('ssh', args, { stdio: 'pipe' })
+    sshProcess = proc
+
+    let stderr = ''
+    proc.stderr?.on('data', (d: Buffer) => { stderr += d.toString() })
+    proc.on('error', (err) => reject(new Error(`ssh not found: ${err.message}`)))
+    proc.on('exit', (code) => {
+      if (sshProcess === null) return // intentional kill
+      reject(new Error(stderr.trim() || `SSH exited with code ${code}`))
+    })
+
+    // Poll until the local port accepts connections (tunnel is ready)
+    let waited = 0
+    const poll = () => {
+      const sock = net.createConnection({ port: localPort, host: '127.0.0.1' })
+      sock.on('connect', () => { sock.destroy(); resolve(localPort) })
+      sock.on('error', () => {
+        waited += 200
+        if (proc.exitCode !== null) return // process already died
+        if (waited < 15000) setTimeout(poll, 200)
+        else reject(new Error('SSH tunnel timed out'))
       })
-
-      tunnelServer = server
-
-      server.listen(localPort, '127.0.0.1', () => resolve(localPort))
-      server.on('error', reject)
-    })
-
-    client.on('error', reject)
-
-    client.connect({
-      host: config.host,
-      port: config.port || 22,
-      username: config.username,
-      privateKey,
-      // TOFU: prompt user on unknown host
-      hostVerifier: (_key: unknown, callback: (result: boolean) => void) => {
-        const knownHostsPath = `${os.homedir()}/.ssh/known_hosts`
-        // If known_hosts doesn't exist or host isn't in it, ask user
-        const hostLine = `${config.host}`
-        const known = fsSync.existsSync(knownHostsPath)
-          ? fsSync.readFileSync(knownHostsPath, 'utf8').includes(hostLine)
-          : false
-        if (known) { callback(true); return }
-        // Prompt user
-        dialog.showMessageBox({
-          type: 'warning',
-          title: 'Unknown SSH Host',
-          message: `The host "${config.host}" is not in your known_hosts.\n\nDo you want to trust it and continue?`,
-          buttons: ['Trust & Connect', 'Cancel'],
-          defaultId: 0,
-          cancelId: 1,
-        }).then(({ response }) => callback(response === 0))
-      },
-    })
+    }
+    setTimeout(poll, 300)
   }))
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawchat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawchat",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@noble/ed25519": "^3.0.0",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -19,14 +19,12 @@
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.0",
         "remark-gfm": "^4.0.1",
-        "ssh2": "^1.17.0",
         "tailwind-merge": "^3.4.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
-        "@types/ssh2": "^1.15.5",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
         "@typescript-eslint/parser": "^8.54.0",
         "@vitejs/plugin-react": "^4.2.1",
@@ -2321,33 +2319,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/ssh2": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
-      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18"
-      }
-    },
-    "node_modules/@types/ssh2/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/ssh2/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3004,15 +2975,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3164,15 +3126,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -3279,15 +3232,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/buildcheck": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
-      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/builder-util": {
       "version": "26.4.1",
@@ -3824,20 +3768,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/cpu-features": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
-      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "~0.0.6",
-        "nan": "^2.19.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/crc": {
       "version": "3.8.0",
@@ -7656,13 +7586,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/nan": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -8742,6 +8665,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -9005,23 +8929,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
-    },
-    "node_modules/ssh2": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
-      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "asn1": "^0.2.6",
-        "bcrypt-pbkdf": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      },
-      "optionalDependencies": {
-        "cpu-features": "~0.0.10",
-        "nan": "^2.23.0"
-      }
     },
     "node_modules/ssri": {
       "version": "12.0.0",
@@ -9441,12 +9348,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,12 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.0",
     "remark-gfm": "^4.0.1",
-    "ssh2": "^1.17.0",
     "tailwind-merge": "^3.4.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
-    "@types/ssh2": "^1.15.5",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,14 +10,6 @@ export default defineConfig({
     electron({
       main: {
         entry: 'electron/main.ts',
-        vite: {
-          build: {
-            rollupOptions: {
-              // ssh2 includes native .node binaries — must not be bundled
-              external: ['ssh2'],
-            },
-          },
-        },
       },
       preload: {
         // Shortcut of `build.rollupOptions.input`.


### PR DESCRIPTION
## Fix: SSH Tunnel

`ssh2` produced `EHOSTUNREACH` on hosts that were reachable via terminal SSH — a known incompatibility with certain macOS network configurations.

Switching to `spawn('ssh', [...])` uses the exact same binary and network stack as the terminal, eliminating the routing discrepancy.

**Changes:**
- Removed `ssh2` + `@types/ssh2` dependencies
- Removed `ssh2` external from `vite.config.ts`
- `createSSHTunnel` now spawns system `ssh` with `-N -L` flags
- Tunnel readiness detected by polling the local port
- `StrictHostKeyChecking=accept-new` handles TOFU automatically
- `destroySSHTunnel` kills the child process