### PR TITLE
fix: use minimal operator scopes

### DIFF
--- a/src/lib/gateway-client.ts
+++ b/src/lib/gateway-client.ts
@@ -320,7 +320,7 @@ export class GatewayClient {
           clientId: 'cli',
           clientMode: 'cli',
           role: 'operator',
-          scopes: ['operator.admin', 'operator.approvals', 'operator.pairing'],
+          scopes: ['operator.read', 'operator.write', 'operator.approvals', 'operator.pairing'],
           signedAtMs: signedAt,
           token: this.token || null,
           nonce: this.challengeNonce,
@@ -340,7 +340,7 @@ export class GatewayClient {
 
     const params: ConnectParams = {
       role: 'operator',
-      scopes: ['operator.admin', 'operator.approvals', 'operator.pairing'],
+      scopes: ['operator.read', 'operator.write', 'operator.approvals', 'operator.pairing'],
       auth: { token: this.token, ...(this.deviceToken ? { deviceToken: this.deviceToken } : {}) },
       ...(device ? { device } : {}),
       client: {


### PR DESCRIPTION
Replaces `operator.admin` with `operator.read` + `operator.write` — the correct minimal scopes per the gateway protocol docs.

`operator.approvals` and `operator.pairing` are retained as ClawChat uses both features.

Fixes the approach discussed — no brute-forcing with admin.