### PR TITLE
fix: dont send device identity without existing deviceToken

### DIFF
--- a/src/lib/gateway-client.ts
+++ b/src/lib/gateway-client.ts
@@ -302,9 +302,9 @@ export class GatewayClient {
 
     // Build device identity only when we already hold a deviceToken
     // (i.e. the device was previously paired). Sending an unsolicited device
-    // field to a token-auth gateway causes "device signature invalid".
+    // field to a token-auth gateway causes rejection ("not-paired").
     let device: DeviceIdentity | undefined
-    if (this.challengeNonce) {
+    if (this.deviceToken && this.challengeNonce) {
       try {
         const identity = await getOrCreateKeyPair()
         const deviceId = await getDeviceId(identity)


### PR DESCRIPTION
## Problem

ClawChat was always building and sending a device identity on connect, even when no prior pairing had occurred. The new gateway (v2026.3.x) rejects unpaired device identities with `pairing-required: not-paired`, even when `dangerouslyDisableDeviceAuth=true`.

## Fix

Only include the device field in connect params when we already have a `deviceToken` from a previous successful pairing. This matches the existing comment in the code which correctly described the intended behavior.

## Testing

Verified locally against gateway v2026.3.x — connection succeeds.