### PR TITLE
fix: clear stuck streaming state on connection drop or stall

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -143,7 +143,7 @@ export function useChat(
       logger.warn('Stream stall detected — no delta for', STREAM_STALL_MS, 'ms')
       clearStalledStream()
     }, STREAM_STALL_MS)
-  }, [clearStalledStream, STREAM_STALL_MS])
+  }, [clearStalledStream])
 
   // When connection drops while streaming, clear the stuck state immediately
   useEffect(() => {


### PR DESCRIPTION
## Problem

Responses stop mid-stream and ClawChat has to be restarted. Two root causes:

### 1. WebSocket drop while streaming
When the WS connection drops and reconnects while a response is streaming, the reconnect path preserves messages (good UX) but never resets `isStreaming` or clears the `streaming: true` bubble. The UI freezes permanently — the only fix is restarting the app.

### 2. No stream timeout
If the gateway stops sending deltas but never sends a `final` event (e.g. silent gateway crash, zombie run), `isStreaming` stays `true` forever with no recovery path.

## Fix

**`src/hooks/useChat.ts`**

1. New `useEffect` watches `status` — if connection drops while streaming, immediately calls `clearStalledStream()` which marks the stuck bubble as errored and resets all streaming state

2. New 90s stall timer (`resetStallTimer`) resets on every delta received. If no delta arrives for 90s, `clearStalledStream()` fires automatically

3. Timer is cleared on `final` and `error` events (normal completion paths)

4. Timer is cleaned up on component unmount

The error message shown: _"Response interrupted — connection lost or timed out."_