### PR TITLE
fix: allow send with image attachment and no text

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -346,7 +346,9 @@ export function useChat(
   }, [activeSessionKey, status])
 
   const send = useCallback(async (text: string, attachments?: ChatAttachment[]) => {
-    if (!client || status !== 'connected' || !text.trim()) return
+    const hasText = text.trim().length > 0
+    const hasAttachments = attachments && attachments.length > 0
+    if (!client || status !== 'connected' || (!hasText && !hasAttachments)) return
 
     // Append user message immediately
     const userMsg: DisplayMessage = {


### PR DESCRIPTION
## Problem
When pasting an image into ClawChat without typing any text, hitting send did nothing — no spinner, no response, no error. The `send()` function in `useChat.ts` had an early bail-out condition:

```ts
if (!client || status !== 'connected' || !text.trim()) return
```

If text is empty (image-only send), the function exits immediately.

## Fix
Allow send to proceed if attachments are present, even with no text:

```ts
const hasText = text.trim().length > 0
const hasAttachments = attachments && attachments.length > 0
if (!client || status !== 'connected' || (!hasText && !hasAttachments)) return
```

Fixes #19