### PR TITLE
fix: immediately clear streaming state on abort

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -411,7 +411,18 @@ export function useChat(
     } catch (err) {
       logger.warn('chat.abort failed:', err)
     }
-    // Streaming end will be handled by the final/error event
+    // Don't rely on the gateway sending a final/error event after abort —
+    // clear streaming state immediately so the UI responds to the button click.
+    activeRunIdRef.current = null
+    pendingLocalSendRef.current = false
+    setIsStreaming(false)
+    setMessages((prev) => {
+      const idx = prev.findIndex((m) => m.streaming && m.role === 'assistant')
+      if (idx < 0) return prev
+      const updated = [...prev]
+      updated[idx] = { ...updated[idx], streaming: false }
+      return updated
+    })
   }, [client, status])
 
   return {


### PR DESCRIPTION
Clears streaming state immediately on abort instead of waiting for the gateway event.

Previously the stop button would not visually reset until the gateway sent a response — this makes it instant.