### PR TITLE
fix: filter HEARTBEAT_OK and NO_REPLY sentinel messages from chat UI

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useMemo, useEffect, useRef, useCallback } from 'react'
 import { MessageBubble } from './MessageBubble'
 import { MessageInput } from './MessageInput'
+import { isSentinelMessage } from '../lib/sentinel'
 import type { DisplayMessage } from '../hooks/useChat'
 import type { ConnectionStatus } from '../types/protocol'
 
@@ -42,19 +43,26 @@ export function ChatView({
     el.scrollTop = el.scrollHeight
   }, [])
 
+  // Filter out agent sentinel messages (HEARTBEAT_OK, NO_REPLY) at the
+  // rendering layer — raw data is preserved in the hook / cache.
+  const visibleMessages = useMemo(
+    () => messages.filter((msg) => !isSentinelMessage(msg.text)),
+    [messages],
+  )
+
   // Auto-scroll on new messages if user is near bottom
   useEffect(() => {
     if (isNearBottomRef.current) {
       scrollToBottom()
     }
-  }, [messages, scrollToBottom])
+  }, [visibleMessages, scrollToBottom])
 
   // Scroll to bottom on history load
   useEffect(() => {
-    if (!historyLoading && messages.length > 0) {
+    if (!historyLoading && visibleMessages.length > 0) {
       scrollToBottom()
     }
-  }, [historyLoading, messages.length, scrollToBottom])
+  }, [historyLoading, visibleMessages.length, scrollToBottom])
 
   const isDisabled = status !== 'connected'
 
@@ -90,7 +98,7 @@ export function ChatView({
           </div>
         )}
 
-        {!historyLoading && messages.length === 0 && (
+        {!historyLoading && visibleMessages.length === 0 && (
           <div style={{
             flex: 1,
             display: 'flex',
@@ -105,12 +113,12 @@ export function ChatView({
           </div>
         )}
 
-        {messages.map((msg) => (
+        {visibleMessages.map((msg) => (
           <MessageBubble key={msg.id} message={msg} botAvatar={botAvatar} botName={botName} />
         ))}
 
         {/* Typing indicator when streaming but no delta yet */}
-        {isStreaming && !messages.some((m) => m.streaming) && (
+        {isStreaming && !visibleMessages.some((m) => m.streaming) && (
           <div style={{
             padding: '0.25rem 1rem',
             display: 'flex',

--- a/src/lib/sentinel.ts
+++ b/src/lib/sentinel.ts
@@ -1,0 +1,21 @@
+/**
+ * Agent sentinel messages — internal protocol signals that should not
+ * be rendered as chat bubbles.  Matching is exact (trimmed, case-sensitive).
+ *
+ * Filtering happens at the rendering layer so raw data is preserved in
+ * history and caches.
+ */
+
+const SENTINEL_MESSAGES: ReadonlySet<string> = new Set([
+  'HEARTBEAT_OK',
+  'NO_REPLY',
+])
+
+/**
+ * Returns true if the message text is a known sentinel that should be
+ * hidden from the chat UI.
+ */
+export function isSentinelMessage(text: string | undefined | null): boolean {
+  if (!text) return false
+  return SENTINEL_MESSAGES.has(text.trim())
+}

--- a/src/test/sentinel.test.ts
+++ b/src/test/sentinel.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { isSentinelMessage } from '../lib/sentinel'
+
+describe('isSentinelMessage', () => {
+  it('returns true for HEARTBEAT_OK', () => {
+    expect(isSentinelMessage('HEARTBEAT_OK')).toBe(true)
+  })
+
+  it('returns true for NO_REPLY', () => {
+    expect(isSentinelMessage('NO_REPLY')).toBe(true)
+  })
+
+  it('returns true with leading/trailing whitespace', () => {
+    expect(isSentinelMessage('  HEARTBEAT_OK  ')).toBe(true)
+    expect(isSentinelMessage('\nNO_REPLY\n')).toBe(true)
+  })
+
+  it('returns false for normal messages', () => {
+    expect(isSentinelMessage('Hello!')).toBe(false)
+    expect(isSentinelMessage('This is a real message')).toBe(false)
+  })
+
+  it('returns false for partial matches', () => {
+    expect(isSentinelMessage('HEARTBEAT_OK and more text')).toBe(false)
+    expect(isSentinelMessage('Prefix NO_REPLY')).toBe(false)
+  })
+
+  it('is case-sensitive', () => {
+    expect(isSentinelMessage('heartbeat_ok')).toBe(false)
+    expect(isSentinelMessage('no_reply')).toBe(false)
+  })
+
+  it('returns false for empty/null/undefined', () => {
+    expect(isSentinelMessage('')).toBe(false)
+    expect(isSentinelMessage(null)).toBe(false)
+    expect(isSentinelMessage(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Filters agent sentinel responses (`HEARTBEAT_OK`, `NO_REPLY`) from the ClawChat message list. These are internal protocol signals — not meaningful conversation — and showing them as chat bubbles is noisy and confusing.

## Implementation

- **`src/lib/sentinel.ts`** — `isSentinelMessage()` utility that checks if trimmed text exactly matches a known sentinel. Uses a `Set` for O(1) lookup and is easily extensible for future blocklist entries.
- **`src/components/ChatView.tsx`** — Filters messages via `useMemo` before rendering. Raw data is preserved in the hook/cache (filtering happens at the rendering layer per the issue spec).
- **`src/test/sentinel.test.ts`** — 7 unit tests covering exact match, whitespace trimming, partial matches, case sensitivity, and null/empty handling.

## Acceptance Criteria

- ✅ `HEARTBEAT_OK` messages do not appear in the chat UI
- ✅ `NO_REPLY` messages do not appear in the chat UI
- ✅ All other messages render as normal
- ✅ No regression on existing message display (raw data preserved)

Closes #21