### PR TITLE
feat: add Claude Code channels as alternative backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">💬 ClawChat</h1>
 
-<p align="center"><strong>Simple desktop client for remote OpenClaw gateways.</strong><br>No Node.js, no npm, no complexity — just download and connect.</p>
+<p align="center"><strong>Desktop client for OpenClaw gateways and Claude Code channels.</strong><br>No Node.js, no npm, no complexity — just download and connect.</p>
 
 ---
 
@@ -16,26 +16,17 @@
 
 ## Why ClawChat?
 
-ClawChat fills a specific gap in the OpenClaw ecosystem: **simple desktop access to remote gateways**.
+ClawChat supports two backends:
 
-### When to use ClawChat:
+### OpenClaw Gateway
+Connect to remote [OpenClaw](https://github.com/openclaw/openclaw) gateways over WebSocket. Full protocol v3 support including streaming deltas, session management, and SSH tunneling.
 
-- ✅ Your gateway runs on a **server** (Linux/remote Mac) and you want to connect from your laptop
-- ✅ You're on **Windows or Linux** (no official OpenClaw desktop app for these platforms)
-- ✅ You want a **lightweight client** without installing Node.js, npm, or managing the gateway locally
-- ✅ You prefer **SSH/Tailscale** setups with a remote gateway
-
-### When to use the official OpenClaw macOS app:
-
-- ✅ You want to **run the gateway locally** on your Mac
-- ✅ You need **native macOS integrations** (TCC permissions, system notifications, etc.)
-- ✅ You want the app to **manage the gateway lifecycle** for you
-
-**Both are great!** Pick the client that matches your setup. [Learn more about OpenClaw](https://github.com/openclaw/openclaw).
+### Claude Code Channels
+Connect to a [Claude Code](https://claude.ai/code) instance running with a custom MCP channel server. Uses your Claude Max subscription — no API billing. Claude Code runs on a server (e.g., Docker), and ClawChat connects via WebSocket to the channel server.
 
 > **🎯 Quick Guide:**
-> - Run gateway locally on Mac? → [OpenClaw macOS App](https://github.com/openclaw/openclaw)
-> - Run gateway on a server (Linux/remote Mac)? → **ClawChat**
+> - Have an OpenClaw gateway? → Select **OpenClaw** tab on connect screen
+> - Have Claude Code + channel server? → Select **Claude Channels** tab
 > - Using Windows or Linux? → **ClawChat** (only cross-platform option)
 
 ---
@@ -50,16 +41,21 @@ Pre-built releases for macOS, Windows, and Linux are available on the [Releases]
 
 Or build from source (see [Quick Start](#quick-start) below).
 
-## Perfect for Remote Gateways
+## Perfect for Remote Backends
 
-ClawChat excels at connecting to **OpenClaw gateways running elsewhere** — whether that's a dedicated server, a home lab, or a cloud instance. 
+ClawChat connects to backends running elsewhere — whether that's a dedicated server, a home lab, or a cloud instance.
 
-**Common setup:**
-1. Run OpenClaw gateway on a Linux server or remote Mac (via SSH/Tailscale)
-2. Install ClawChat on your laptop (Mac, Windows, or Linux)
-3. Connect via WebSocket — no Node.js installation required on your laptop
+**OpenClaw setup:**
+1. Run OpenClaw gateway on a Linux server or remote Mac
+2. Install ClawChat on your laptop
+3. Connect via WebSocket (direct or SSH tunnel)
 
-Your conversations and credentials stay on your infrastructure. ClawChat is just a lightweight UI that talks to your gateway.
+**Claude Channels setup:**
+1. Run Claude Code in a Docker container with a channel server (MCP)
+2. The channel server exposes a WebSocket endpoint
+3. Install ClawChat on your laptop and connect
+
+Your conversations and credentials stay on your infrastructure. ClawChat is just a lightweight UI.
 
 ## Features
 
@@ -86,7 +82,7 @@ Node mode (camera, screen recording, system commands) is planned for a future re
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) 18+
-- A running [OpenClaw Gateway](https://docs.openclaw.ai)
+- A running [OpenClaw Gateway](https://docs.openclaw.ai) or Claude Code channel server
 
 ### Install
 
@@ -112,18 +108,145 @@ Outputs packaged binaries to `release/` directory.
 
 ## Connecting
 
-### Local Gateway
+### OpenClaw Gateway
 
 1. Launch ClawChat
-2. Enter your gateway URL (e.g., `ws://localhost:18789`)
-3. Enter your gateway auth token
-4. Click **Connect**
+2. Select the **OpenClaw** tab
+3. Enter your gateway URL (e.g., `ws://localhost:18789`)
+4. Enter your gateway auth token
+5. Click **Connect**
 
-Your credentials are saved locally and the app will auto-connect on subsequent launches.
+For remote gateways, use the **SSH Tunnel** toggle to connect securely:
+
+```bash
+# Or manually from terminal:
+ssh -N -L 18789:127.0.0.1:18789 your-gateway-host
+```
+
+### Claude Code Channels
+
+1. Launch ClawChat
+2. Select the **Claude Channels** tab
+3. Enter your channel server URL (e.g., `ws://your-server:9700`)
+4. Click **Connect** (token is optional if the server doesn't require one)
+
+#### Setting up the channel server
+
+The channel server is an MCP server that runs as a subprocess of Claude Code. It bridges WebSocket connections from ClawChat to Claude Code's channel notification system.
+
+**Prerequisites:**
+- A server with Docker
+- Claude Max subscription
+- OAuth token from `claude setup-token`
+
+**1. Docker container setup:**
+
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  claude-code:
+    image: node:22-slim
+    container_name: claude-code
+    env_file:
+      - .env
+    working_dir: /workspace
+    ports:
+      - "9700:9700"
+    volumes:
+      - /path/to/workspace:/workspace
+      - claude-cache:/root/.claude
+    environment:
+      - TERM=xterm-256color
+      - COLORTERM=truecolor
+    command: >
+      bash -c "
+        apt-get update && apt-get install -y git tmux vim ripgrep curl &&
+        npm install -g @anthropic-ai/claude-code &&
+        ln -sf /root/.claude/.claude.json /root/.claude.json &&
+        tail -f /dev/null
+      "
+    restart: unless-stopped
+
+volumes:
+  claude-cache:
+```
+
+Create `.env`:
+```
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-your-token-here
+```
+
+**2. Channel server:**
+
+Create `/workspace/channel-test/package.json`:
+```json
+{
+  "name": "channel-test",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "ws": "^8.0.0",
+    "uuid": "^9.0.0"
+  }
+}
+```
+
+Create `/workspace/channel-test/server.mjs` — an MCP channel server that:
+- Connects to Claude Code over stdio (channel capability)
+- Exposes a WebSocket server on port 9700 for ClawChat
+- Translates between ClawChat's protocol and MCP channel notifications
+- Registers a `send_reply` tool for Claude to respond through
+
+See the [channel server source](https://github.com/ngmaloney/clawchat/blob/feature/channel-backend/channel-server-example.md) for the full implementation.
+
+Create `/workspace/.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "channel-test": {
+      "command": "node",
+      "args": ["/workspace/channel-test/server.mjs"],
+      "env": { "CHANNEL_PORT": "9700" }
+    }
+  }
+}
+```
+
+**3. First-time setup inside the container:**
+
+```bash
+# Install dependencies
+cd /workspace/channel-test && npm install
+
+# Set onboarding flags to skip the wizard
+node -e "
+const fs = require('fs');
+const d = JSON.parse(fs.readFileSync('/root/.claude/.claude.json','utf8'));
+d.hasCompletedOnboarding = true;
+d.theme = 'dark';
+fs.writeFileSync('/root/.claude/.claude.json', JSON.stringify(d, null, 2));
+"
+```
+
+**4. Start Claude Code with channels:**
+
+```bash
+tmux new-session -d -s claude "claude --permission-mode default \
+  --allowedTools mcp__channel-test__send_reply \
+  --dangerously-load-development-channels server:channel-test"
+```
+
+Accept the development channels warning when prompted. Claude will show "Listening for channel messages from: server:channel-test" when ready.
+
+**5. Add personality (optional):**
+
+Create `/workspace/CLAUDE.md` with a system prompt / personality. Claude Code reads this automatically every session.
 
 ## Using Slash Commands
 
-ClawChat supports OpenClaw slash commands for controlling your agent and session. Type `/` in the message input to see available commands:
+ClawChat supports OpenClaw slash commands when connected to an OpenClaw gateway. Type `/` in the message input to see available commands:
 
 - `/new` — Start a new session
 - `/model` — Show or switch models
@@ -134,24 +257,7 @@ ClawChat supports OpenClaw slash commands for controlling your agent and session
 - `/verbose` — Toggle verbose output
 - `/reset` — Reset the current session
 
-Commands autocomplete as you type. Just start typing `/` and select from the menu.
-
-### Remote Gateway via SSH Tunnel
-
-If your OpenClaw gateway runs on a different machine (e.g., a dedicated server), use SSH port forwarding to securely tunnel the connection:
-
-```bash
-ssh -N -L 18789:127.0.0.1:18789 your-gateway-host
-```
-
-Example:
-```bash
-ssh -N -L 18789:127.0.0.1:18789 ts140
-```
-
-Then connect ClawChat to `ws://localhost:18789` as if the gateway were local. The SSH tunnel encrypts all traffic between your desktop and the gateway server.
-
-> **Note:** For local WebSocket connections without device identity, ensure your gateway config has `gateway.controlUi.allowInsecureAuth: true` set.
+Commands autocomplete as you type.
 
 ## Tech Stack
 
@@ -165,7 +271,7 @@ Then connect ClawChat to `ws://localhost:18789` as if the gateway were local. Th
 
 ## Architecture
 
-ClawChat implements the OpenClaw Gateway Protocol v3, including proper handshake, request/response correlation, and event streaming.
+ClawChat implements the OpenClaw Gateway Protocol v3 and Claude Code channel protocol, including handshake, request/response correlation, and event streaming.
 
 ```
 electron/          # Main process (Node.js)
@@ -174,11 +280,12 @@ electron/          # Main process (Node.js)
 
 src/               # Renderer process (React)
   lib/
-    gateway-client.ts    # WebSocket protocol implementation
+    gateway-client.ts    # WebSocket protocol (OpenClaw + Channels)
   hooks/
     useGateway.ts        # Connection state management
     useChat.ts           # Message & session state
   components/
+    ConnectScreen.tsx    # Backend selection + auth
     Dashboard.tsx        # Main UI layout
     ChatView.tsx         # Message list
     MessageInput.tsx     # Input with file upload

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useState } from 'react'
 import { ConnectScreen } from './components/ConnectScreen'
 import { Dashboard } from './components/Dashboard'
 import { useGateway } from './hooks/useGateway'
+import type { BackendType } from './lib/gateway-client'
 import { logger } from './lib/logger'
 
 function App() {
-  const [credentials, setCredentials] = useState<{ url: string; token: string; deviceToken?: string } | null>(null)
+  const [credentials, setCredentials] = useState<{ url: string; token: string; backend: BackendType; deviceToken?: string } | null>(null)
   const [loading, setLoading] = useState(true)
 
   // Load saved credentials on mount — skip auto-connect for SSH mode
@@ -19,11 +20,18 @@ function App() {
           setLoading(false)
           return
         }
-        const url = await window.api.store.get('gatewayUrl') as string
-        const token = await window.api.store.get('token') as string
+        const backend = (await window.api.store.get('backend') as BackendType) || 'openclaw'
+        let url: string, token: string
+        if (backend === 'channel') {
+          url = await window.api.store.get('channelUrl') as string
+          token = await window.api.store.get('channelToken') as string
+        } else {
+          url = await window.api.store.get('gatewayUrl') as string
+          token = await window.api.store.get('token') as string
+        }
         const deviceToken = await window.api.store.get('deviceToken') as string | undefined
         if (url && token) {
-          setCredentials({ url, token, deviceToken })
+          setCredentials({ url, token, backend, deviceToken })
         }
       } catch (err) {
         logger.warn('Failed to load saved credentials:', err)
@@ -37,20 +45,27 @@ function App() {
   const { status, client, disconnect } = useGateway({
     url: credentials?.url || '',
     token: credentials?.token || '',
+    backend: credentials?.backend ?? 'openclaw',
     deviceToken: credentials?.deviceToken,
     autoConnect: !!credentials,
   })
 
   const [isSshMode, setIsSshMode] = useState(false)
 
-  const handleConnect = useCallback(async (url: string, token: string) => {
+  const handleConnect = useCallback(async (url: string, token: string, backend: BackendType = 'openclaw') => {
     const tunnelMode = url.startsWith('ws://127.0.0.1:')
     setIsSshMode(tunnelMode)
-    setCredentials({ url, token })
+    setCredentials({ url, token, backend })
+    await window.api.store.set('backend', backend)
     // Don't persist the ephemeral tunnel URL — SSH config is saved by ConnectScreen
     if (!tunnelMode) {
-      await window.api.store.set('gatewayUrl', url)
-      await window.api.store.set('token', token)
+      if (backend === 'openclaw') {
+        await window.api.store.set('gatewayUrl', url)
+        await window.api.store.set('token', token)
+      } else {
+        await window.api.store.set('channelUrl', url)
+        await window.api.store.set('channelToken', token)
+      }
     }
   }, [])
 

--- a/src/components/ConnectScreen.tsx
+++ b/src/components/ConnectScreen.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
 import type { ConnectionStatus } from '../types/protocol'
+import type { BackendType } from '../lib/gateway-client'
 
 interface ConnectScreenProps {
-  onConnect: (url: string, token: string) => void
+  onConnect: (url: string, token: string, backend: BackendType) => void
   status: ConnectionStatus
 }
 
@@ -28,13 +29,18 @@ const labelStyle = {
 }
 
 export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
+  const [backend, setBackend] = useState<BackendType>('openclaw')
   const [mode, setMode] = useState<ConnectMode>('direct')
 
-  // Direct mode
-  const [url, setUrl] = useState('ws://localhost:18789')
-  const [token, setToken] = useState('')
+  // OpenClaw state
+  const [ocUrl, setOcUrl] = useState('ws://localhost:18789')
+  const [ocToken, setOcToken] = useState('')
 
-  // SSH mode
+  // Channel state
+  const [chUrl, setChUrl] = useState('ws://tc1.home.wrox.us:9700')
+  const [chToken, setChToken] = useState('')
+
+  // SSH mode (OpenClaw only)
   const [sshHost, setSshHost] = useState('')
   const [sshPort, setSshPort] = useState('22')
   const [sshUser, setSshUser] = useState('')
@@ -47,18 +53,24 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
   useEffect(() => {
     const load = async () => {
       try {
-        const savedUrl = await window.api.store.get('gatewayUrl') as string
-        const savedToken = await window.api.store.get('token') as string
+        const savedBackend = await window.api.store.get('backend') as BackendType
         const savedMode = await window.api.store.get('connectMode') as ConnectMode
+        const savedOcUrl = await window.api.store.get('gatewayUrl') as string
+        const savedOcToken = await window.api.store.get('token') as string
+        const savedChUrl = await window.api.store.get('channelUrl') as string
+        const savedChToken = await window.api.store.get('channelToken') as string
         const savedSshHost = await window.api.store.get('sshHost') as string
         const savedSshPort = await window.api.store.get('sshPort') as string
         const savedSshUser = await window.api.store.get('sshUser') as string
         const savedSshKeyPath = await window.api.store.get('sshKeyPath') as string
         const savedSshRemotePort = await window.api.store.get('sshRemotePort') as string
 
-        if (savedUrl) setUrl(savedUrl)
-        if (savedToken) setToken(savedToken)
+        if (savedBackend) setBackend(savedBackend)
         if (savedMode) setMode(savedMode)
+        if (savedOcUrl) setOcUrl(savedOcUrl)
+        if (savedOcToken) setOcToken(savedOcToken)
+        if (savedChUrl) setChUrl(savedChUrl)
+        if (savedChToken) setChToken(savedChToken)
         if (savedSshHost) setSshHost(savedSshHost)
         if (savedSshPort) setSshPort(savedSshPort)
         if (savedSshUser) setSshUser(savedSshUser)
@@ -71,19 +83,26 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
     load()
   }, [])
 
+  // Active URL/token based on backend
+  const url = backend === 'openclaw' ? ocUrl : chUrl
+  const token = backend === 'openclaw' ? ocToken : chToken
+  const setUrl = backend === 'openclaw' ? setOcUrl : setChUrl
+  const setToken = backend === 'openclaw' ? setOcToken : setChToken
+
+  const showSsh = backend === 'openclaw' && mode === 'ssh'
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setSshError('')
 
-    if (mode === 'direct') {
-      if (url && token) onConnect(url, token)
+    if (!showSsh) {
+      if (url && (token || backend === 'channel')) onConnect(url, token, backend)
       return
     }
 
-    // SSH tunnel mode
+    // SSH tunnel mode (OpenClaw only)
     setIsTunneling(true)
     try {
-      // Persist SSH config
       await window.api.store.set('connectMode', 'ssh')
       await window.api.store.set('sshHost', sshHost)
       await window.api.store.set('sshPort', sshPort)
@@ -104,8 +123,7 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
         return
       }
 
-      // Connect via the local tunnel port
-      onConnect(`ws://127.0.0.1:${result.localPort}`, token)
+      onConnect(`ws://127.0.0.1:${result.localPort}`, token, backend)
     } catch (err) {
       setSshError((err as Error).message || 'SSH tunnel failed')
     } finally {
@@ -132,53 +150,83 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
         <h1 style={{ fontSize: '1.5rem', fontWeight: 600, margin: '0.5rem 0', color: '#fff' }}>
           ClawChat
         </h1>
-        <p style={{ color: '#888', fontSize: '0.875rem' }}>
-          Connect to your OpenClaw Gateway
-        </p>
       </div>
 
-      {/* Mode toggle */}
+      {/* Backend tabs */}
       <div style={{
         display: 'flex',
-        backgroundColor: '#16213e',
-        borderRadius: '8px',
-        padding: '3px',
+        width: '320px',
         marginBottom: '1.25rem',
-        border: '1px solid #2a2a4a',
+        borderBottom: '2px solid #2a2a4a',
       }}>
-        {(['direct', 'ssh'] as ConnectMode[]).map((m) => (
+        {([['openclaw', 'OpenClaw'], ['channel', 'Claude Channels']] as const).map(([b, label]) => (
           <button
-            key={m}
+            key={b}
             type="button"
-            onClick={() => { setMode(m); setSshError('') }}
+            onClick={() => { setBackend(b as BackendType); setSshError('') }}
             style={{
-              padding: '0.375rem 1rem',
-              borderRadius: '6px',
+              flex: 1,
+              padding: '0.625rem 0',
               border: 'none',
-              fontSize: '0.8rem',
-              fontWeight: 500,
+              borderBottom: backend === b ? '2px solid #e85d04' : '2px solid transparent',
+              marginBottom: '-2px',
+              fontSize: '0.875rem',
+              fontWeight: 600,
               cursor: 'pointer',
-              backgroundColor: mode === m ? '#e85d04' : 'transparent',
-              color: mode === m ? '#fff' : '#888',
+              backgroundColor: 'transparent',
+              color: backend === b ? '#fff' : '#666',
               transition: 'all 0.15s',
             }}
           >
-            {m === 'direct' ? 'Direct' : 'SSH Tunnel'}
+            {label}
           </button>
         ))}
       </div>
 
+      {/* Connection mode toggle — OpenClaw only */}
+      {backend === 'openclaw' && (
+        <div style={{
+          display: 'flex',
+          backgroundColor: '#16213e',
+          borderRadius: '8px',
+          padding: '3px',
+          marginBottom: '1.25rem',
+          border: '1px solid #2a2a4a',
+        }}>
+          {(['direct', 'ssh'] as ConnectMode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => { setMode(m); setSshError('') }}
+              style={{
+                padding: '0.375rem 1rem',
+                borderRadius: '6px',
+                border: 'none',
+                fontSize: '0.8rem',
+                fontWeight: 500,
+                cursor: 'pointer',
+                backgroundColor: mode === m ? '#e85d04' : 'transparent',
+                color: mode === m ? '#fff' : '#888',
+                transition: 'all 0.15s',
+              }}
+            >
+              {m === 'direct' ? 'Direct' : 'SSH Tunnel'}
+            </button>
+          ))}
+        </div>
+      )}
+
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '320px' }}>
 
-        {mode === 'direct' ? (
+        {!showSsh ? (
           <>
             <div>
-              <label style={labelStyle}>Gateway URL</label>
+              <label style={labelStyle}>{backend === 'openclaw' ? 'Gateway URL' : 'Channel URL'}</label>
               <input
                 type="text"
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
-                placeholder="ws://localhost:18789"
+                placeholder={backend === 'openclaw' ? 'ws://localhost:18789' : 'ws://host:9700'}
                 disabled={isConnecting}
                 style={inputStyle}
               />
@@ -189,7 +237,7 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
                 type="password"
                 value={token}
                 onChange={(e) => setToken(e.target.value)}
-                placeholder="Enter your Gateway token"
+                placeholder={backend === 'openclaw' ? 'Enter your Gateway token' : 'Enter your Channel token'}
                 disabled={isConnecting}
                 style={inputStyle}
               />
@@ -273,7 +321,7 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
 
         <button
           type="submit"
-          disabled={isConnecting || !token || (mode === 'direct' ? !url : !sshHost || !sshUser)}
+          disabled={isConnecting || (backend === 'openclaw' && !token) || (!showSsh ? !url : !sshHost || !sshUser)}
           style={{
             padding: '0.75rem',
             backgroundColor: isConnecting ? '#333' : '#e85d04',
@@ -301,7 +349,7 @@ export function ConnectScreen({ onConnect, status }: ConnectScreenProps) {
           </p>
         )}
 
-        {mode === 'ssh' && (
+        {showSsh && (
           <p style={{ color: '#555', fontSize: '0.7rem', textAlign: 'center', margin: 0 }}>
             Connects via SSH key auth. Password auth not supported.
           </p>

--- a/src/hooks/useGateway.ts
+++ b/src/hooks/useGateway.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { GatewayClient } from '../lib/gateway-client'
+import type { BackendType } from '../lib/gateway-client'
 import type { ConnectionStatus } from '../types/protocol'
 
 export type { ConnectionStatus }
@@ -7,6 +8,7 @@ export type { ConnectionStatus }
 interface UseGatewayOptions {
   url: string
   token: string
+  backend?: BackendType
   deviceToken?: string
   autoConnect?: boolean
 }
@@ -18,7 +20,7 @@ export interface GatewayHandle {
   disconnect: () => void
 }
 
-export function useGateway({ url, token, deviceToken, autoConnect = false }: UseGatewayOptions): GatewayHandle {
+export function useGateway({ url, token, backend, deviceToken, autoConnect = false }: UseGatewayOptions): GatewayHandle {
   const [status, setStatus] = useState<ConnectionStatus>('disconnected')
   const [client, setClient] = useState<GatewayClient | null>(null)
   // Internal ref for callbacks that need stable access without re-subscribing
@@ -26,11 +28,12 @@ export function useGateway({ url, token, deviceToken, autoConnect = false }: Use
 
   // Create / recreate the client when url or token change
   useEffect(() => {
-    if (!url || !token) return
+    if (!url || (!token && backend !== 'channel')) return
 
     const newClient = new GatewayClient({
       url,
       token,
+      backend,
       deviceToken,
       onStatusChange: (s) => setStatus(s),
       onDeviceToken: (dt) => {
@@ -51,7 +54,7 @@ export function useGateway({ url, token, deviceToken, autoConnect = false }: Use
       clientRef.current = null
       setClient(null)
     }
-  }, [url, token, deviceToken, autoConnect])
+  }, [url, token, backend, deviceToken, autoConnect])
 
   const connect = useCallback(() => {
     clientRef.current?.connect()

--- a/src/lib/gateway-client.ts
+++ b/src/lib/gateway-client.ts
@@ -36,9 +36,12 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>
 }
 
+export type BackendType = 'openclaw' | 'channel'
+
 export interface GatewayClientOptions {
   url: string
   token: string
+  backend?: BackendType
   deviceToken?: string
   onStatusChange?: (status: ConnectionStatus) => void
   onEvent?: (event: string, payload: Record<string, unknown>) => void
@@ -74,6 +77,7 @@ export class GatewayClient {
 
   private readonly url: string
   private readonly token: string
+  private readonly backend: BackendType
   private readonly onStatusChange?: (status: ConnectionStatus) => void
   private readonly onEvent?: (event: string, payload: Record<string, unknown>) => void
   private readonly onDeviceToken?: (token: string) => void
@@ -83,6 +87,7 @@ export class GatewayClient {
   constructor(opts: GatewayClientOptions) {
     this.url = opts.url
     this.token = opts.token
+    this.backend = opts.backend ?? 'openclaw'
     this.deviceToken = opts.deviceToken
     this.onStatusChange = opts.onStatusChange
     this.onEvent = opts.onEvent
@@ -176,7 +181,7 @@ export class GatewayClient {
     this.ws = ws
 
     ws.onopen = () => {
-      logger.debug('WS open, awaiting connect.challenge…')
+      logger.debug(`WS open (${this.backend}), awaiting handshake…`)
       this._setStatus('handshaking')
     }
 
@@ -260,7 +265,15 @@ export class GatewayClient {
   private _handleEvent(frame: EventFrame): void {
     const { event, payload } = frame
 
-    // Handle connect.challenge → capture nonce, then perform handshake
+    // Channel backend: connect.welcome means we're connected (no handshake needed)
+    if (event === 'connect.welcome') {
+      logger.info('Channel connected — no handshake required')
+      this.retryCount = 0
+      this._setStatus('connected')
+      return
+    }
+
+    // OpenClaw backend: connect.challenge → capture nonce, then perform handshake
     if (event === 'connect.challenge') {
       this.challengeNonce = (payload.nonce as string) ?? null
       this._doHandshake()


### PR DESCRIPTION
## Summary

Adds Claude Code channels as a second backend option alongside OpenClaw. ClawChat can now connect to a Claude Code instance running with a custom MCP channel server, using the Max subscription instead of requiring an OpenClaw gateway.

### What changed

**`src/lib/gateway-client.ts`**
- Added `BackendType` (`'openclaw' | 'channel'`) and `backend` field to `GatewayClientOptions`
- New handler for `connect.welcome` event — channel servers use this simplified handshake instead of OpenClaw's `connect.challenge` → Ed25519 → `hello-ok` flow
- OpenClaw flow is completely untouched — the channel path is additive

**`src/components/ConnectScreen.tsx`**
- Replaced single connect form with tabbed interface: **OpenClaw** | **Claude Channels**
- Each backend maintains its own URL and token state (switching tabs doesn't clobber values)
- SSH tunnel toggle only shows for OpenClaw (channels connect directly)
- Token is optional for channel backend (server may not require auth)
- Defaults: OpenClaw → `ws://localhost:18789`, Channels → `ws://tc1.home.wrox.us:9700`

**`src/App.tsx`**
- Credentials now include `backend` type
- Channel credentials persisted separately (`channelUrl`/`channelToken` vs `gatewayUrl`/`token`)
- Auto-connect on launch loads the correct credentials based on last-used backend

**`src/hooks/useGateway.ts`**
- Passes `backend` through to `GatewayClient`
- Allows empty token for channel backend (doesn't block client creation)

**`README.md`**
- Updated tagline and intro to mention both backends
- Added full Claude Channels setup guide: Docker compose, channel server, MCP config, first-time container setup, launching Claude with channels, and optional personality via CLAUDE.md
- Restructured "Connecting" section with separate instructions per backend

### How it works

The channel server is an MCP server that runs as a subprocess of Claude Code. It has two interfaces:
- **stdio** → talks to Claude Code (MCP channel notifications)
- **WebSocket** → talks to ClawChat (same req/res/event protocol)

```
ClawChat ──WebSocket──→ Channel Server (MCP + WS)
                            │ stdio
                            ▼
                        Claude Code (interactive, with --dangerously-load-development-channels)
```

When ClawChat sends a `chat.send` request:
1. Channel server acks immediately with a `runId`
2. Sends `notifications/claude/channel` to Claude via MCP
3. Claude processes the message and calls the `send_reply` tool
4. Channel server broadcasts the reply as a `chat` event (state: `final`) with the matching `runId`
5. ClawChat displays the response

### What's NOT changed

- OpenClaw gateway flow — zero changes to handshake, crypto, protocol, or behavior
- useChat.ts — no changes needed, both backends emit the same event format
- useSessions.ts — channel server implements `sessions.list` compatibly
- All existing tests pass unchanged
- MessageBubble, MessageInput, ChatView, Dashboard — all unchanged

### Known limitations

- No streaming deltas from channels — Claude's response arrives as a single `final` event (not incremental deltas). The response appears all at once rather than streaming word-by-word.
- Channel server requires Claude Code running interactively (in tmux) with `--dangerously-load-development-channels` — this is a research preview feature
- The dev channels warning prompt must be accepted manually after each container restart
- Single conversation per Claude Code instance (no multi-session support yet)

## Test plan

- [ ] Select **OpenClaw** tab → enter gateway URL + token → Connect → verify full chat flow with streaming deltas
- [ ] Select **Claude Channels** tab → enter channel server URL → Connect → verify chat flow with final responses
- [ ] Switch between tabs → verify URL/token fields are independent and don't clobber each other
- [ ] Connect to channels → disconnect → reconnect → verify auto-reconnect works
- [ ] Verify saved credentials load correctly on app restart for both backends
- [ ] Run `npm test` — all 12 tests pass
- [ ] Run `npx tsc --noEmit` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)